### PR TITLE
SAGE-1622: upgrade to v2.3.0 of RPi support debian package

### DIFF
--- a/Dockerfile.rootfs
+++ b/Dockerfile.rootfs
@@ -127,11 +127,11 @@ RUN wget https://github.com/waggle-sensor/waggle-common-tools/releases/download/
 
 # Core only apps - RPi
 RUN if [ -z "$AGENT_MODE" ]; then \
-    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.2.0/sage-rpi-pxeboot_2.2.0_all.deb ; \
-    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.2.0/sage-rpi-pxeboot-boot_2.2.0_all.deb ; \
-    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.2.0/sage-rpi-pxeboot-os-usrlibfw_2.2.0_all.deb ; \
-    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.2.0/sage-rpi-pxeboot-os-usrlib_2.2.0_all.deb ; \
-    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.2.0/sage-rpi-pxeboot-os-other_2.2.0_all.deb ; \
+    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.3.0/sage-rpi-pxeboot_2.3.0_all.deb ; \
+    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.3.0/sage-rpi-pxeboot-boot_2.3.0_all.deb ; \
+    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.3.0/sage-rpi-pxeboot-os-usrlibfw_2.3.0_all.deb ; \
+    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.3.0/sage-rpi-pxeboot-os-usrlib_2.3.0_all.deb ; \
+    wget https://github.com/waggle-sensor/waggle-rpi-pxeboot/releases/download/v2.3.0/sage-rpi-pxeboot-os-other_2.3.0_all.deb ; \
     fi
 
 # Core only apps - Others


### PR DESCRIPTION
- fix PxE boot failure of new RPi 4 hardware
- disable unused service cloud-init